### PR TITLE
Load auth document when picking a library on welcome screen

### DIFF
--- a/Simplified/NYPLSettingsAccountsList.swift
+++ b/Simplified/NYPLSettingsAccountsList.swift
@@ -95,6 +95,7 @@
     AccountsManager.shared.loadCatalogs(preferringCache: false) { (success) in
       guard success else {
         let alert = NYPLAlertController.alert(withTitle:nil, singleMessage:NSLocalizedString("CheckConnection", comment: ""))
+        alert?.addAction(UIAlertAction.init(title: NSLocalizedString("OK", comment: ""), style: .cancel))
         alert?.present(fromViewControllerOrNil:self, animated:true, completion:nil)
         return
       }


### PR DESCRIPTION
This is an annoyingly large amount of code, but the shorter options I could think of seemed more convoluted, with more nested completion blocks. Instead I went with more helper functions.

I also fixed an alert I had put in before and not tested. When testing the alerts here (by making the library list and auth document loading fail after a second artificially), I noticed that not including an OK option made it impossible to dismiss the alert.